### PR TITLE
Do not duplicate parameter if both form and path parameters with same name are present

### DIFF
--- a/rest_framework_swagger/introspectors.py
+++ b/rest_framework_swagger/introspectors.py
@@ -280,6 +280,20 @@ class BaseMethodIntrospector(object):
         form_params = self.build_form_parameters()
         query_params = self.build_query_parameters()
 
+        new_form_params = []
+        if form_params and path_params:
+            for param in form_params:
+                for pparam in path_params:
+                    if param['name'] == pparam['name']:
+                        pparam['description']  = param['description']
+                        #pparam['type']         = param['type']
+                        #pparam['format']       = param['format']
+                        #pparam['required']     = param['required']
+                        #pparam['defaultValue'] = param['defaultValue']
+                    else:
+                        new_form_params.append(param)
+        form_params = new_form_params
+
         if path_params:
             params += path_params
 


### PR DESCRIPTION
Path parameters are duplicated as form parameters if they are specified in serializers. This patch merges form parameter to path parameter with same name (just description for now, rest needs to be discussed) and removes it from form parameters.
